### PR TITLE
style(marketplace): remove gradient backgrounds from icons

### DIFF
--- a/server/marketplace/baselayout.ejs
+++ b/server/marketplace/baselayout.ejs
@@ -97,7 +97,7 @@
         .logo-icon {
             width: 40px;
             height: 40px;
-            background: linear-gradient(135deg, #4f46e5, #7c3aed);
+            /* background: linear-gradient(135deg, #4f46e5, #7c3aed); */
             border-radius: 8px;
             display: flex;
             align-items: center;

--- a/server/marketplace/styles.css
+++ b/server/marketplace/styles.css
@@ -347,7 +347,7 @@ body {
 .plugin-icon {
     width: 5rem;
     height: 5rem;
-    background: linear-gradient(135deg, #e0e7ff 0%, #dbeafe 100%);
+    /* background: linear-gradient(135deg, #e0e7ff 0%, #dbeafe 100%); */
     border-radius: 1.25rem;
     display: flex;
     align-items: center;
@@ -987,7 +987,7 @@ body {
 .plugin-icon {
     width: 3rem;
     height: 3rem;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    /* background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); */
     border-radius: 0.5rem;
     display: flex;
     align-items: center;


### PR DESCRIPTION
The gradient backgrounds were commented out to simplify the visual design and improve consistency across the marketplace interface. This change makes the icons more neutral and better suited for various color schemes.